### PR TITLE
不正なDateオブジェクトをisDateで判定できるように修正

### DIFF
--- a/src/as-safely.test.ts
+++ b/src/as-safely.test.ts
@@ -184,6 +184,11 @@ describe('isDate', () => {
     const unknown: unknown = 1;
     expect(isDate(unknown)).toStrictEqual(false);
   });
+
+  test('should return false when invalid date is provided', () => {
+    const unknown: unknown = new Date('test');
+    expect(isDate(unknown)).toStrictEqual(false);
+  });
 });
 
 describe('isArray', () => {

--- a/src/as-safely.ts
+++ b/src/as-safely.ts
@@ -27,7 +27,7 @@ const isSymbol = (obj: unknown): obj is symbol => typeof obj === 'symbol';
 const isBigint = (obj: unknown): obj is bigint => typeof obj === 'bigint';
 const isUndefined = (obj: unknown): obj is undefined => typeof obj === 'undefined';
 const isNull = (obj: unknown): obj is null => obj === null;
-const isDate = (obj: unknown): obj is Date => obj instanceof Date;
+const isDate = (obj: unknown): obj is Date => obj instanceof Date && !isNaN(obj.getTime());
 const isArray = <ELEMENT = unknown>(elementCondition: (element: unknown) => element is ELEMENT) => {
   return (obj: unknown): obj is ELEMENT[] => Array.isArray(obj) && obj.every(elementCondition);
 };


### PR DESCRIPTION
## 発生していたこと
```typescript
import { asSafely, isDate } from 'as-safely'

asSafely(new Date("2020-01-01"), isDate)
// => 例外を投げない（意図通り）

asSafely('hoge', isDate)
// => 例外を投げる（意図通り）

asSafely(new Date('hoge'), isDate)
// => 例外を投げない（意図通り？）
```

上記の例のように、現状のisDate関数では不正なDateオブジェクトを検知できませんでした。
手元で `as-safely` を利用させていただいているプロジェクトでは不正なDateオブジェクトはisDateで検知したかったので修正していますが、もし当リポジトリの方針にも合うようであれば、採用していただけると嬉しいです。

参考：
```bash
$ node
Welcome to Node.js v16.15.1.
Type ".help" for more information.
> new Date("hoge")
Invalid Date
> typeof new Date("hoge")
'object'
> new Date("hoge") instanceof Date
true
> new Date("hoge").getTime()
NaN
```